### PR TITLE
Adding sqlite3 peer table.

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,33 @@ var p2p = P2PSpider({
     timeout: 10000
 });
 
+var sqlite3 = require('sqlite3').verbose();
+var dbFile = path.join(__dirname, "peers.sqlite3");
+var db;
+
+// Create the tables if the file doesn't exist
+fs.access(dbFile, fs.F_OK, function(err) {
+    db = new sqlite3.Database(dbFile);
+    if (err) {
+        db.serialize(function() {
+            db.run("create table peers (infohash varchar(40), peer varchar(40))");
+            db.run("create unique index peer_unique on peers(infohash, peer)");
+        });
+    }
+});
+
 p2p.ignore(function (infohash, rinfo, callback) {
     var torrentFilePathSaveTo = path.join(__dirname, "torrents", infohash + ".torrent");
+
+    console.log('Saving peer for ' + infohash);
+    db.serialize(function() {
+        db.run("insert into peers (infohash, peer) values ('" + infohash + "','"  + rinfo.address + "')", function(err) {
+            if (err) {
+                console.error(err);
+            }
+        });
+    });
+
     fs.exists(torrentFilePathSaveTo, function(exists) {
         callback(exists); //if is not exists, download the metadata.
     });

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "scripts": {},
   "dependencies": {
     "bencode": "^0.7.0",
-    "bitfield": "^1.1.2"
+    "bitfield": "^1.1.2",
+    "sqlite3": "^3.1.8"
   },
   "keywords": [
     "torrent",


### PR DESCRIPTION
This creates an sqlite3 DB if it doesn't exist, and adds a `peers` table with (infohash, peer) columns. 

You can then get peer counts by running:
```sql
select infohash, count(*) from peers group by infohash;
```