### PR TITLE
Increase buffer size to UDP max size 65535

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -187,7 +187,7 @@ func (d *dht) run() {
 }
 
 func (d *dht) listen() {
-	buf := make([]byte, 2048)
+	buf := make([]byte, 65535)
 	for {
 		n, addr, err := d.conn.ReadFromUDP(buf)
 		if err == nil {


### PR DESCRIPTION
This fixed https://github.com/fanpei91/torsniff/issues/88 for me. See https://en.wikipedia.org/wiki/User_Datagram_Protocol for the size.

Maybe Windows 10/11 reassembles fragmented UDP packets automatically, so the buffer size of 2048 which is normally enough for any internet MTU, could not be enough on Windows.